### PR TITLE
inlining array access gives huge improvement in speed.

### DIFF
--- a/test_vla.nim
+++ b/test_vla.nim
@@ -3,38 +3,46 @@ import vla, times
 let 
   s = "Warning: unknown magic 'DeepCopy' might crash the compiler [UnknownMagic]"
 
-var count = 0
+var 
+  vla_count = 0
+  seq_count = 0
 
-proc test_oa(n : int, a: openarray[char]) = 
+proc test_oa(count : var int, a: openarray[char]) =
   count += len(a)
 
-proc test_vla(n : int) = 
+proc test_vla(n : int) =
   var vla = newVLA(char, n)
   for i in countup(0,n-1):
     vla[i] = s[i]
-  test_oa(n, asOpenArray(vla))
+  test_oa(vla_count, asOpenArray(vla))
 
-proc test_seq(n : int) = 
-  var seqVal : seq[char] = @[]
+proc test_seq(n : int) =
+  var seqVal = new_seq[char](n)
   for i in countup(0,n-1):
-    seqVal.add(s[i])
-  test_oa(n, seqVal)
+    seqVal[i] = s[i]
+  test_oa(seq_count, seqVal)
 
 # Time the VLA
 var t0 = cpuTime()
 for n in 0..100000:
   for i in 0..len(s):
     test_vla(i)
-var t1 = cpuTime()
-echo("alloca time = ", (t1 - t0))
+
+var vla_time = cpuTime() - t0
+echo("alloca time = ", vla_time)
+echo("vla count = ", vla_count)
 
 # Time Nim's built in seq
+t0 = cpuTime()
 for n in 0..100000:
   for i in 0..len(s):
     test_seq(i)
-var t2 = cpuTime()
-echo("seq time = ", (t2 - t1))
-echo("count = ", count)
+
+var seq_time = cpuTime() - t0
+echo("seq time = ", seq_time)
+echo("seq count = ", seq_count)
+
+echo("speedup = ", float64(seq_time) / float64(vla_time))
 
 discard r"""
 proc test_ragged_vla(nrows:int, ncols:int) = 

--- a/vla.nim
+++ b/vla.nim
@@ -8,14 +8,13 @@ type
   VarLengthArray*[T] =
     ptr object
       len: int
-      reserved: int
       data: UncheckedArray[T]
 
-proc `[]`*[T](a: VarLengthArray[T], i: int): T =
+proc `[]`*[T](a: VarLengthArray[T], i: int): T {.inline.} =
   assert i >= 0 and i < a.len
   result = a.data[i]
 
-proc `[]=`*[T](a: VarLengthArray[T], i: int, x: T) =
+proc `[]=`*[T](a: VarLengthArray[T], i: int, x: T) {.inline.} =
   assert i >= 0 and i < a.len
   a.data[i] = x
 
@@ -23,11 +22,10 @@ proc len*[T](a: VarLengthArray[T]): int =
   a.len
 
 template newVLA*(T: typedesc, n: int): untyped =
-  let bytes = 2 * sizeof(int) + sizeof(T)*n
+  let bytes = sizeof(int) + sizeof(T)*n
   var vla = cast[VarLengthArray[T]](alloca(bytes))
   c_memset(vla, 0, bytes)
   vla.len = n
-  vla.reserved = n
   vla
 
 # Untested code


### PR DESCRIPTION
without inlining, this is actually slower than a fully allocated seq (preallocating instead of relying on add).
after inlining, it is 5X faster than the seq equivalent.